### PR TITLE
Add support for privileged option

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ If the output should include the long descriptions of the linting results, set t
 
 Set to `true` to disable linting rules only relevant to listed extensions. Default: `false`
 
+### `privileged`
+
+Set to `true` to disable the error when using privileged manifest fields. Default: `false`
+
 ## Example usage
 
 ```yaml

--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,10 @@ inputs:
     description: 'Enable to indicate the extension will be self hosted'
     required: false
     default: false
+  privileged:
+    description: 'Enable to treat the extension as a privileged extension'
+    required: false
+    default: false
 runs:
   using: 'node16'
   main: 'index.js'

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ import path from 'node:path';
 const NONE = 0,
     FIRST = 1,
     source = core.getInput('extension-root') || '.',
+    privileged = core.getInput('privileged') || false,
     selfHosted = /true/.test(core.getInput('self-hosted'));
 //TODO support explicit config path?
 
@@ -36,6 +37,7 @@ function formatMessage(lintReport) {
 webExt.cmd.lint({
     sourceDir: source,
     output: 'none',
+    privileged: privileged,
     selfHosted
 },
 {


### PR DESCRIPTION
This adds support for the "--privileged" argument (Treat your extension as a privileged extension) of the web-ext lint command.