### PR TITLE
Do not ignore typings directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,9 +40,6 @@ build/Release
 # Dependency directories
 jspm_packages/
 
-# TypeScript v1 declaration files
-typings/
-
 # TypeScript cache
 *.tsbuildinfo
 


### PR DESCRIPTION
To run as github action, the typings directories must also be added and updated.

If they are ignored and updated without adding, you may get a message like this:
`Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/home/runner/work/_actions/tatankat/web-ext-lint/v2/node_modules/yargs/build/lib/typings/common-types.js' imported from /home/runner/work/_actions/tatankat/web-ext-lint/v2/node_modules/yargs/build/lib/yargs-factory.js`